### PR TITLE
phpfpm container renamed to php

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This file is provided as an example development environment using Mage Inferno M
 app:
   image: mageinferno/magento2-nginx:1.9.14-0
   links:
-    - phpfpm
+    - php:phpfpm
     - db
   volumes_from:
     - appdata
@@ -33,7 +33,7 @@ appdata:
 #    - ~/.composer:/var/www/.composer
 #    - ./www/app/code:/srv/www/app/code
 
-phpfpm:
+php:
   image: mageinferno/magento2-php:7.0.5-fpm-0
   links:
     - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 app:
   image: mageinferno/magento2-nginx:1.9.14-0
   links:
-    - phpfpm
+    - php:phpfpm
     - db
   volumes_from:
     - appdata
@@ -18,7 +18,7 @@ appdata:
 #    - ~/.composer:/var/www/.composer
 #    - ./www/app/code:/srv/www/app/code
 
-phpfpm:
+php:
   image: mageinferno/magento2-php:7.0.5-fpm-0
   links:
     - db


### PR DESCRIPTION
The phpfpm container has also phpcli, so maybe it would be better to rename it to just `php`.

Then you can simply run

```
docker-compose exec php bin/magento ...
```

(as of docker-compose 1.7.x).