### PR TITLE
Fixed setup image version, Enterprise installation support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ dbdata:
     - /var/lib/mysql
 
 setup:
-  image: mageinferno/magento2-php:7.0-fpm-0
+  image: mageinferno/magento2-php:7.1-fpm-0
   command: /usr/local/bin/mage-setup
   links:
     - db


### PR DESCRIPTION
Enterprise installation wasn't working using the 7.0 image. 

The setup script included in that image doesn't support the `M2SETUP_USE_COMPOSER_ENTERPRISE` variable.

Looking at the image used for phpfpm, it seems like the setup one should have been bumped too?